### PR TITLE
Changes readOSArgs to readOSArg

### DIFF
--- a/v1/plugin/grpc_tls_test.go
+++ b/v1/plugin/grpc_tls_test.go
@@ -199,33 +199,33 @@ func TestIncorrectPluginArgsFail(t *testing.T) {
 	FocusConvey("Intending to start secure plugin server", t, func() {
 		setUpSecureTestcase(true, true)
 		Convey("omitting Cert Path from arguments will make plugin fail", func() {
-			mockInputOutputInUse.mockArgs = strings.Fields(fmt.Sprintf(`mock
+			mockInputOutputInUse.mockArg = fmt.Sprintf(`
 				{"KeyPath":"%s","TLSEnabled":true}`,
-				tlsTestSrv+keyFileExt))
+				tlsTestSrv+keyFileExt)
 			So(func() {
 				startSecureGrpcPlugin(t, &mockCollector{}, collectorType, "mock-coll")
 			}, ShouldPanic)
 		})
 		Convey("omitting Key Path from arguments will make plugin fail", func() {
-			mockInputOutputInUse.mockArgs = strings.Fields(fmt.Sprintf(`mock
+			mockInputOutputInUse.mockArg = fmt.Sprintf(`
 				{"CertPath":"%s","TLSEnabled":true}`,
-				tlsTestSrv+crtFileExt))
+				tlsTestSrv+crtFileExt)
 			So(func() {
 				startSecureGrpcPlugin(t, &mockCollector{}, collectorType, "mock-coll")
 			}, ShouldPanic)
 		})
 		Convey("omitting TLSEnabled flag from arguments will make plugin fail", func() {
-			mockInputOutputInUse.mockArgs = strings.Fields(fmt.Sprintf(`mock
+			mockInputOutputInUse.mockArg = fmt.Sprintf(`
 				{"CertPath":"%s","KeyPath":"%s"}`,
-				tlsTestSrv+crtFileExt, tlsTestSrv+keyFileExt))
+				tlsTestSrv+crtFileExt, tlsTestSrv+keyFileExt)
 			So(func() {
 				startSecureGrpcPlugin(t, &mockCollector{}, collectorType, "mock-coll")
 			}, ShouldPanic)
 		})
 		Convey("adding mismatched certificate and key in arguments will make plugin fail", func() {
-			mockInputOutputInUse.mockArgs = strings.Fields(fmt.Sprintf(`mock
+			mockInputOutputInUse.mockArg = fmt.Sprintf(`
 				{"CertPath":"%s","KeyPath":"%s","TLSEnabled":true}`,
-				tlsTestSrv+crtFileExt, tlsTestCli+keyFileExt))
+				tlsTestSrv+crtFileExt, tlsTestCli+keyFileExt)
 			So(func() {
 				startSecureGrpcPlugin(t, &mockCollector{}, collectorType, "mock-coll")
 			}, ShouldPanic)
@@ -421,9 +421,9 @@ func setUpSecureTestcase(serverTLSUp, clientTLSUp bool) {
 	tlsSetup = testTLSSetupInUse
 	grpcOptsBuilderInUse = newGrpcOptsBuilder()
 	if serverTLSUp {
-		mockInputOutputInUse.mockArgs = strings.Fields(fmt.Sprintf(`mock
+		mockInputOutputInUse.mockArg = fmt.Sprintf(`
 			{"CertPath":"%s","KeyPath":"%s","TLSEnabled":true,"LogLevel":5}`,
-			tlsTestSrv+crtFileExt, tlsTestSrv+keyFileExt))
+			tlsTestSrv+crtFileExt, tlsTestSrv+keyFileExt)
 		testTLSSetupInUse.caCertPath = tlsTestCA + crtFileExt
 	}
 	if clientTLSUp {

--- a/v1/plugin/mocks_test.go
+++ b/v1/plugin/mocks_test.go
@@ -1,4 +1,4 @@
-// +build small medium
+// + build small medium
 
 /*
 http://www.apache.org/licenses/LICENSE-2.0.txt
@@ -229,15 +229,15 @@ func (ms *mockServer) Serve(net.Listener) error {
 }
 
 type mockInputOutput struct {
-	mockArgs        []string
+	mockArg         string
 	output          []string
-	doReadOSArgs    func() []string
+	doReadOSArg     func() string
 	doPrintOut      func(string)
 	prevInputOutput OSInputOutput
 }
 
-func (f *mockInputOutput) readOSArgs() []string {
-	return f.doReadOSArgs()
+func (f *mockInputOutput) readOSArg() string {
+	return f.doReadOSArg()
 }
 
 func (f *mockInputOutput) printOut(data string) {
@@ -253,13 +253,13 @@ func (f *mockInputOutput) args() int {
 }
 
 func newMockInputOutput(prevInputOutput OSInputOutput) *mockInputOutput {
-	mock := mockInputOutput{mockArgs: []string{"mock", "{\"LogLevel\": 5}"}}
+	mock := mockInputOutput{mockArg: "{\"LogLevel\": 5}"}
 	mock.prevInputOutput = prevInputOutput
 	mock.doPrintOut = func(data string) {
 		mock.output = append(mock.output, data)
 	}
-	mock.doReadOSArgs = func() []string {
-		return mock.mockArgs
+	mock.doReadOSArg = func() string {
+		return mock.mockArg
 	}
 	return &mock
 }

--- a/v1/plugin/plugin.go
+++ b/v1/plugin/plugin.go
@@ -147,8 +147,8 @@ type tlsServerSetup interface {
 
 // osInputOutput supports interactions with OS for the plugin lib
 type OSInputOutput interface {
-	// readOSArgs gets command line arguments passed to application
-	readOSArgs() []string
+	// readOSArg gets first argument
+	readOSArg() string
 	// printOut outputs given data to application standard output
 	printOut(data string)
 
@@ -166,12 +166,15 @@ type standardInputOutput struct {
 // libInputOutput holds utility used for OS interactions
 var libInputOutput OSInputOutput = &standardInputOutput{}
 
-// readOSArgs implementation that returns application args passed by OS
-func (io *standardInputOutput) readOSArgs() []string {
+// readOSArgs implementation that returns the first arg
+func (io *standardInputOutput) readOSArg() string {
 	if io.context != nil {
-		return io.context.Args().Tail()
+		return io.context.Args().First()
 	}
-	return os.Args
+	if len(os.Args) > 0 {
+		return os.Args[0]
+	}
+	return ""
 }
 
 // printOut implementation that emits data into standard output

--- a/v1/plugin/plugin_test.go
+++ b/v1/plugin/plugin_test.go
@@ -75,13 +75,13 @@ func TestParsingArgs(t *testing.T) {
 		mockInputOutput := newMockInputOutput(libInputOutput)
 		libInputOutput = mockInputOutput
 		Convey("ListenPort should be properly parsed", func() {
-			mockInputOutput.mockArgs = strings.Fields(`main {"ListenPort":"4414"}`)
+			mockInputOutput.mockArg = `{"ListenPort":"4414"}`
 			args, err := getArgs()
 			So(err, ShouldBeNil)
 			So(args.ListenPort, ShouldEqual, "4414")
 		})
 		Convey("PingTimeoutDuration should be properly parsed", func() {
-			mockInputOutput.mockArgs = strings.Fields(`main {"PingTimeoutDuration":3141}`)
+			mockInputOutput.mockArg = `{"PingTimeoutDuration":3141}`
 			args, err := getArgs()
 			So(err, ShouldBeNil)
 			So(args.PingTimeoutDuration, ShouldEqual, 3141)

--- a/v1/plugin/session.go
+++ b/v1/plugin/session.go
@@ -38,14 +38,13 @@ type Arg struct {
 
 // getArgs returns plugin args or default ones
 func getArgs() (*Arg, error) {
-	osArgs := libInputOutput.readOSArgs()
+	osArg := libInputOutput.readOSArg()
 	// default parameters - can be parsed as JSON
-	paramStr := "{}"
-	if len(osArgs) > 1 && osArgs[1] != "" {
-		paramStr = osArgs[1]
+	if osArg == "" {
+		osArg = "{}"
 	}
 	arg := &Arg{}
-	err := json.Unmarshal([]byte(paramStr), arg)
+	err := json.Unmarshal([]byte(osArg), arg)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
cli.Context.Args().Tail() returns all arguments excluding the first.  Replaced `Tail()` with `First()` and renamed the method to readOSArg and return only the first argument since this is all that plugins accept.  Note: flags are already considered args in this context since the CLI framework has already processed the raw os.Args().