### PR TITLE
Set rpcType as gRPCStream for streaming plugin

### DIFF
--- a/v1/plugin/meta.go
+++ b/v1/plugin/meta.go
@@ -133,8 +133,8 @@ func newMeta(plType pluginType, name string, version int, opts ...MetaOpt) *meta
 		Type:             plType,
 		ConcurrencyCount: defaultConcurrencyCount,
 		RoutingStrategy:  LRURouter,
-		RPCType:          2, // GRPC type
-		RPCVersion:       1, // This is v1 lib
+		RPCType:          gRPC, // GRPC type
+		RPCVersion:       1,    // This is v1 lib
 		// Unsecure is a legacy value not used for grpc, but needed to avoid
 		// calling SetKey needlessly.
 		Unsecure: true,

--- a/v1/plugin/meta_test.go
+++ b/v1/plugin/meta_test.go
@@ -50,15 +50,15 @@ func metaTestCases() []metaTestCase {
 	tc := []metaTestCase{
 		metaTestCase{
 			input:  *newMeta(collectorType, "fakeCollector", 0, ConcurrencyCount(0), Exclusive(false), RoutingStrategy(LRURouter), CacheTTL(time.Millisecond*0)),
-			output: meta{Type: collectorType, Name: "fakeCollector", Version: 0, ConcurrencyCount: 0, Exclusive: false, RoutingStrategy: 0, RPCType: 2, RPCVersion: 1, Unsecure: true, CacheTTL: time.Millisecond * 0},
+			output: meta{Type: collectorType, Name: "fakeCollector", Version: 0, ConcurrencyCount: 0, Exclusive: false, RoutingStrategy: 0, RPCType: gRPC, RPCVersion: 1, Unsecure: true, CacheTTL: time.Millisecond * 0},
 		},
 		metaTestCase{
 			input:  *newMeta(processorType, "fakeProcessor", 1, ConcurrencyCount(1), Exclusive(true), RoutingStrategy(StickyRouter), CacheTTL(time.Millisecond*1)),
-			output: meta{Type: processorType, Name: "fakeProcessor", Version: 1, ConcurrencyCount: 1, Exclusive: true, RoutingStrategy: 1, RPCType: 2, RPCVersion: 1, Unsecure: true, CacheTTL: time.Millisecond * 1},
+			output: meta{Type: processorType, Name: "fakeProcessor", Version: 1, ConcurrencyCount: 1, Exclusive: true, RoutingStrategy: 1, RPCType: gRPC, RPCVersion: 1, Unsecure: true, CacheTTL: time.Millisecond * 1},
 		},
 		metaTestCase{
 			input:  *newMeta(publisherType, "fakePublisher", 10, ConcurrencyCount(8), Exclusive(false), RoutingStrategy(ConfigBasedRouter), CacheTTL(time.Millisecond*1)),
-			output: meta{Type: publisherType, Name: "fakePublisher", Version: 10, ConcurrencyCount: 8, Exclusive: false, RoutingStrategy: 2, RPCType: 2, RPCVersion: 1, Unsecure: true, CacheTTL: time.Millisecond * 1},
+			output: meta{Type: publisherType, Name: "fakePublisher", Version: 10, ConcurrencyCount: 8, Exclusive: false, RoutingStrategy: 2, RPCType: gRPC, RPCVersion: 1, Unsecure: true, CacheTTL: time.Millisecond * 1},
 		},
 	}
 	return tc

--- a/v1/plugin/plugin.go
+++ b/v1/plugin/plugin.go
@@ -402,6 +402,8 @@ func StartStreamCollector(plugin StreamCollector, name string, version int, opts
 	appArgs.plugin = plugin
 	appArgs.name = name
 	appArgs.version = version
+	//set gRPCStream as RPC type
+	opts = append(opts, rpcType(gRPCStream))
 	appArgs.opts = opts
 	app.Version = strconv.Itoa(version)
 	app.Usage = "a Snap collector"
@@ -487,7 +489,7 @@ func startPlugin(c *cli.Context) error {
 			maxMetricsBuffer:   defaultMaxMetricsBuffer,
 		}
 		pluginProxy = &proxy.pluginProxy
-		server, meta, err = buildGRPCServer(publisherType, appArgs.name, appArgs.version, arg, appArgs.opts...)
+		server, meta, err = buildGRPCServer(collectorType, appArgs.name, appArgs.version, arg, appArgs.opts...)
 		if err != nil {
 			return cli.NewExitError(err, 2)
 		}

--- a/v1/plugin/plugin_test.go
+++ b/v1/plugin/plugin_test.go
@@ -98,6 +98,10 @@ func TestPlugin(t *testing.T) {
 			i := StartCollector(newMockCollector(), "collector", 0, Exclusive(true), RoutingStrategy(1))
 			So(i, ShouldEqual, 0)
 		})
+		Convey("stream collector plugin should start successfully", func() {
+			i := StartStreamCollector(newMockStreamer(), "collector", 1)
+			So(i, ShouldEqual, 0)
+		})
 		Convey("processor plugin should start successfully", func() {
 			j := StartProcessor(newMockProcessor(), "processor", 1, Exclusive(false))
 			So(j, ShouldEqual, 0)


### PR DESCRIPTION
### Summary of changes
 - set rpcType as gRPCStream for streaming plugin - see [here](https://github.com/jcooklin/snap-plugin-lib-go/compare/fb/adds-standalone-support...IzabellaRaulin:fix_streaming?expand=1#diff-01c2cbb747cc453d78a7b29d3e51c7d7R406);
 - set `collectorType` for streaming collector - see [here](https://github.com/jcooklin/snap-plugin-lib-go/compare/fb/adds-standalone-support...IzabellaRaulin:fix_streaming?expand=1#diff-01c2cbb747cc453d78a7b29d3e51c7d7R492)
- others minor changes:
    - used `gRPC` instead 2
    - added test for streaming collector


Notice:
I have some doubts about allowing set RPCType value by opts in plugin metadata - two values are possible now: 2 (gRPC) and 3(gRPCStream). 
I suppose, that 
 - when I call `plugin.StartStreamCollector` RPCType` should be set to 3. 
 - when I call `plugin.StartCollector` RPCType` should be set to 2
**and I do not need to set RPCtype via opts** what might cause an issue.
@jcooklin - if you agree with that above, I can open an issue to address that, so it might be changed in the future.



