### PR TITLE
Adding support for setting the command line flags MaxMetricsBuffer and MaxCollectDuration

### DIFF
--- a/v1/plugin/flags.go
+++ b/v1/plugin/flags.go
@@ -62,4 +62,15 @@ var (
 		Usage: "specify http port when stand-alone is set",
 		Value: 8181,
 	}
+	collectDurationStr   = "5s"
+	flMaxCollectDuration = cli.StringFlag{
+		Name:        "max-collect-duration",
+		Usage:       "sets the maximum duration (always greater than 0s) between collections before metrics are sent. Defaults to 10s what means that after 10 seconds no new metrics are received, the plugin should send whatever data it has in the buffer instead of waiting longer. (e.g. 5s)",
+		Destination: &collectDurationStr,
+	}
+
+	flMaxMetricsBuffer = cli.Int64Flag{
+		Name:  "max-metrics-buffer",
+		Usage: "maximum number of metrics the plugin is buffering before sending metrics. Defaults to zero what means send metrics immediately.",
+	}
 )

--- a/v1/plugin/session.go
+++ b/v1/plugin/session.go
@@ -37,6 +37,9 @@ type Arg struct {
 
 	// Flag requesting server to establish TLS channel
 	TLSEnabled bool
+
+	MaxCollectDuration string
+	MaxMetricsBuffer   int64
 }
 
 // processArg is provided *Arg and returns *Arg after unmarshaling the first command line argument which is expected to be valid JSON.

--- a/v1/plugin/stream_collector_proxy.go
+++ b/v1/plugin/stream_collector_proxy.go
@@ -158,16 +158,16 @@ func (p *StreamProxy) streamRecv(ch chan []Metric, stream rpc.StreamCollector_St
 			if s != nil {
 				if s.MaxMetricsBuffer > 0 {
 					logger.WithFields(log.Fields{
-						"option": "max_collect_duration",
+						"option": "max-metrics-buffer",
 						"value":  s.MaxMetricsBuffer,
-					}).Debug("setting max collect duration option")
+					}).Debug("setting max metrics buffer option")
 					p.setMaxMetricsBuffer(s.MaxMetricsBuffer)
 				}
 				if s.MaxCollectDuration > 0 {
 					logger.WithFields(log.Fields{
-						"option": "max_metrics_buffer",
+						"option": "max-collect-duration",
 						"value":  fmt.Sprintf("seconds %v", time.Duration(s.MaxCollectDuration).Seconds()),
-					}).Debug("setting max metrics buffer option")
+					}).Debug("setting max collect duration option")
 					p.setMaxCollectDuration(time.Duration(s.MaxCollectDuration))
 				}
 				if s.Metrics_Arg != nil {


### PR DESCRIPTION
Summary of changes:
- Add MaxMetricsBuffer and MaxCollectDuration as flags 
- Set the flags when creating StreamProxy

Testing:
- Manual